### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,7 @@ Installation
 
 ### With composer
 
-Add to `composer.json`:
-
-````json
-{
-    "require": {
-        "prewk/xml-string-streamer": "dev-master"
-    }
-}
-
-````
-
-Run `composer install`.
+Run `composer require prewk/xml-string-streamer-guzzle` to install this package.
 
 Usage
 -----


### PR DESCRIPTION
Because instructing people to use "dev-master" is probably not a good idea

http://blog.doh.ms/2014/10/13/installing-composer-packages/