### PR TITLE
Fix exception import

### DIFF
--- a/src/XmlStringStreamer/Parser/UniqueNode.php
+++ b/src/XmlStringStreamer/Parser/UniqueNode.php
@@ -71,7 +71,7 @@ class UniqueNode implements ParserInterface
     /**
      * Parser constructor
      * @param array $options An options array
-     * @throws \Exception if the required option uniqueNode isn't set
+     * @throws Exception if the required option uniqueNode isn't set
      */
     public function __construct(array $options = array())
     {
@@ -80,7 +80,7 @@ class UniqueNode implements ParserInterface
         ), $options);
 
         if (!isset($this->options["uniqueNode"])) {
-            throw new \Exception("Required option 'uniqueNode' not set");
+            throw new Exception("Required option 'uniqueNode' not set");
         }
     }
 

--- a/src/XmlStringStreamer/Parser/UniqueNode.php
+++ b/src/XmlStringStreamer/Parser/UniqueNode.php
@@ -9,6 +9,7 @@
 
 namespace Prewk\XmlStringStreamer\Parser;
 
+use Exception;
 use Prewk\XmlStringStreamer\ParserInterface;
 use Prewk\XmlStringStreamer\StreamInterface;
 


### PR DESCRIPTION
At the moment, the UniqueNode Parser doesn't import the Exception class.

For this reason, the getExtractedContainer() Method is currently trying to instantiate a (nonexisting) Prewk\XmlStringStreamer\Parser\Exception in case the extractContainer option was not set.
This is fixed by the first included commit.

The second commit harmonizes the usage of the Exception class throughout the UniqueNode class: Previously, an \Exception was thrown in the constructor.. but now that we've imported the Exception class, it seems cleaner to use it directly (as seen in the StringWalker)