### PR TITLE
StringWalker should handle self-closing tags

### DIFF
--- a/src/XmlStringStreamer/Parser/StringWalker.php
+++ b/src/XmlStringStreamer/Parser/StringWalker.php
@@ -232,7 +232,7 @@ class StringWalker implements ParserInterface
                 if ($this->depth === $this->options["captureDepth"] && $depth > 0) {
                     // Yes, we've just entered capture depth, start capturing
                     $this->capture = true;
-                } else if ($this->depth === $this->options["captureDepth"] - 1 && $depth < 0) {
+                } else if ($this->depth === $this->options["captureDepth"] - 1 && $depth <= 0) {
                     // No, we've just exited capture depth, stop capturing and prepare for flush      
                     $flush = true;
                     $this->capture = false;


### PR DESCRIPTION
When i try to use the StringWalker, self-closing tags seem te get skipped from the streamer.
I've been digging a bit, and the issue seems to be in file 'StringWalker.php' on line 233.