### PR TITLE
Allow consuming same stream multiple times

### DIFF
--- a/src/XmlStringStreamer/Stream/File.php
+++ b/src/XmlStringStreamer/Stream/File.php
@@ -51,9 +51,9 @@ class File implements StreamInterface
             }
             
             return $buffer;
-        } else {
-            return false;
         }
+        
+        return false;
     }
 
     public function isSeekable()

--- a/src/XmlStringStreamer/Stream/File.php
+++ b/src/XmlStringStreamer/Stream/File.php
@@ -33,6 +33,12 @@ class File implements StreamInterface
         $this->chunkSize = $chunkSize;
         $this->chunkCallback = $chunkCallback;
     }
+    
+    public function __destruct() {
+        if (is_resource($this->handle)) {
+            fclose($this->handle);
+        }
+    }
 
     public function getChunk()
     {
@@ -46,7 +52,6 @@ class File implements StreamInterface
             
             return $buffer;
         } else if (is_resource($this->handle)) {
-            fclose($this->handle);
             return false;
         } else {
             return false;

--- a/src/XmlStringStreamer/Stream/File.php
+++ b/src/XmlStringStreamer/Stream/File.php
@@ -51,8 +51,6 @@ class File implements StreamInterface
             }
             
             return $buffer;
-        } else if (is_resource($this->handle)) {
-            return false;
         } else {
             return false;
         }


### PR DESCRIPTION
Follow-up of #67 
Sometimes you want to consume the same file multiple times. #67 added the option to rewind the stream but sadly the stream gets closed in https://github.com/prewk/xml-string-streamer/blob/567aa4803730a0f66c8908be93b98d4ec0a2cc60/src/XmlStringStreamer/Stream/File.php#L49 after the file got completely read.

Consequently it is not possible at the moment to read the stream multiple times, for example with the following code:
```php
$parser = new XmlStringStreamer\Parser\UniqueNode($options);
$stream = new XmlStringStreamer\Stream\File(fopen('file.xml', 'rb'));
$streamer = new XmlStringStreamer($parser, $stream);

while ($node = $streamer->getNode()) {
    // do something
}

$stream->rewind(); // does not work because stream is already closed
```

The `rewind()` throws the following error:
```
Warning: stream_get_meta_data(): supplied resource is not a valid stream resource in [...]/vendor\/prewk\/xml-string-streamer\/src\/XmlStringStreamer\/Stream\/File.php:58
```