### PR TITLE
Fix PHP version information in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Installation
 ### Legacy support
 
 * All versions below 1 support PHP 5.3 - 7.2
-* Version 1 and above support PHP 7.3+
+* Version 1 and above support PHP 7.2+
 
 ### With composer
 


### PR DESCRIPTION
The composer.json says this package requires PHP 7.2+ and the tests also run on PHP 7.2, but the readme says this package requires PHP 7.3+. I assume that's a typo in the readme. If not, please decline and update the composer.json accordingly.