### PR TITLE
Add wrapper support to File stream

### DIFF
--- a/src/XmlStringStreamer/Stream/File.php
+++ b/src/XmlStringStreamer/Stream/File.php
@@ -23,10 +23,6 @@ class File implements StreamInterface
                     // Remove wrapper for file_exists() check.
                     $realPath = substr($realPath, strlen($matched[0]));
                 }
-                switch ($matched[1]) {
-                    default:
-                        $filePath = null;
-                }
             }
             // If there's a real disk path to check, make sure it exists
             if ($realPath !== null && !file_exists($realPath)) {
@@ -86,7 +82,4 @@ class File implements StreamInterface
         $this->readBytes = 0;
         rewind($this->handle);
     }
-
-    private function getFilePath($str)
-    {}
 }

--- a/src/XmlStringStreamer/Stream/File.php
+++ b/src/XmlStringStreamer/Stream/File.php
@@ -29,7 +29,6 @@ class File implements StreamInterface
                 throw new \Exception("File '$realPath' doesn't exist");
             }
             $this->handle = fopen($mixed, 'rb');
-            $this->handle;
         } elseif (is_resource($mixed) && get_resource_type($mixed) === "stream") {
             $this->handle = $mixed;
         } else {

--- a/tests/integration/XmlStringStreamer/Stream/FileIntegrationTest.php
+++ b/tests/integration/XmlStringStreamer/Stream/FileIntegrationTest.php
@@ -60,8 +60,8 @@ class FileIntegrationTest extends TestCase
 
     public function test_compressed_file()
     {
-        if (!extension_loaded('zlib')) {
-            $this->markTestSkipped('zlib extension not installed');
+        if (!extension_loaded("zlib")) {
+            $this->markTestSkipped("zlib extension is not installed");
         }
 
         $chunk1 = "1234567890";
@@ -70,17 +70,32 @@ class FileIntegrationTest extends TestCase
         $full = $chunk1 . $chunk2;
 
         $tmpFile = tempnam(sys_get_temp_dir(), "xmlss-phpunit");
-        $wp = fopen('compress.zlib://' . $tmpFile, 'wb');
+        $wp = fopen("compress.zlib://$tmpFile", "wb");
         fwrite($wp, $full, $bufferSize);
         fclose($wp);
 
         file_put_contents($tmpFile, $full);
 
-        $stream = new File('compress.zlib://' . $tmpFile, $bufferSize);
+        $stream = new File("compress.zlib://$tmpFile", $bufferSize);
 
         $this->assertEquals($stream->getChunk(), $chunk1, "First chunk received from the stream should be as expected");
         $this->assertEquals($stream->getChunk(), $chunk2, "Second chunk received from the stream should be as expected");
         $this->assertEquals($stream->getChunk(), false, "Third chunk received from the stream should be false");
+    }
+
+    public function test_remote_stream()
+    {
+        if (ini_get("allow_url_fopen") !== "1") {
+            $this->markTestSkipped("allow_url_fopen is disabled");
+        }
+
+        $chunk1 = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<!DOCTYPE PubmedArticleSet";
+        $bufferSize = 65;
+
+        $url = "ftp://ftp.ncbi.nlm.nih.gov/pubmed/sample-2019-01-01/example.xml";
+        $stream = new File($url, $bufferSize);
+
+        $this->assertEquals($chunk1, $stream->getChunk(), "First chunk received from the stream should be as expected");
     }
 
     public function test_rewind()

--- a/tests/integration/XmlStringStreamer/Stream/FileIntegrationTest.php
+++ b/tests/integration/XmlStringStreamer/Stream/FileIntegrationTest.php
@@ -92,7 +92,7 @@ class FileIntegrationTest extends TestCase
         $chunk1 = "<?xml version=\"1.0\" encoding=\"iso-8859-1\" ?>\n<!DOCTYPE html PUBLIC";
         $bufferSize = 66;
 
-        $url = "https://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        $url = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
         $stream = new File($url, $bufferSize);
 
         $this->assertEquals($chunk1, $stream->getChunk(), "First chunk received from the stream should be as expected");

--- a/tests/integration/XmlStringStreamer/Stream/FileIntegrationTest.php
+++ b/tests/integration/XmlStringStreamer/Stream/FileIntegrationTest.php
@@ -89,10 +89,10 @@ class FileIntegrationTest extends TestCase
             $this->markTestSkipped("allow_url_fopen is disabled");
         }
 
-        $chunk1 = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<!DOCTYPE PubmedArticleSet";
-        $bufferSize = 65;
+        $chunk1 = "<?xml version=\"1.0\" encoding=\"iso-8859-1\" ?>\n<!DOCTYPE html PUBLIC";
+        $bufferSize = 66;
 
-        $url = "ftp://ftp.ncbi.nlm.nih.gov/pubmed/sample-2019-01-01/example.xml";
+        $url = "https://www.w3.org/TR/2001/REC-xml-c14n-20010315";
         $stream = new File($url, $bufferSize);
 
         $this->assertEquals($chunk1, $stream->getChunk(), "First chunk received from the stream should be as expected");

--- a/tests/integration/XmlStringStreamer/Stream/FileIntegrationTest.php
+++ b/tests/integration/XmlStringStreamer/Stream/FileIntegrationTest.php
@@ -58,6 +58,31 @@ class FileIntegrationTest extends TestCase
         $this->assertEquals($callbackCount, $chunkCount, "Chunk callback count should be the same as getChunk count");
     }
 
+    public function test_compressed_file()
+    {
+        if (!extension_loaded('zlib')) {
+            $this->markTestSkipped('zlib extension not installed');
+        }
+
+        $chunk1 = "1234567890";
+        $chunk2 = "abcdefghij";
+        $bufferSize = 10;
+        $full = $chunk1 . $chunk2;
+
+        $tmpFile = tempnam(sys_get_temp_dir(), "xmlss-phpunit");
+        $wp = fopen('compress.zlib://' . $tmpFile, 'wb');
+        fwrite($wp, $full, $bufferSize);
+        fclose($wp);
+
+        file_put_contents($tmpFile, $full);
+
+        $stream = new File('compress.zlib://' . $tmpFile, $bufferSize);
+
+        $this->assertEquals($stream->getChunk(), $chunk1, "First chunk received from the stream should be as expected");
+        $this->assertEquals($stream->getChunk(), $chunk2, "Second chunk received from the stream should be as expected");
+        $this->assertEquals($stream->getChunk(), false, "Third chunk received from the stream should be false");
+    }
+
     public function test_rewind()
     {
         $chunk1 = "1234567890";


### PR DESCRIPTION
This change allows usage of common compression wrappers like `compress.zlib`, as well as URL wrappers for remote files.