### PR TITLE
add Reset Parser state to fully support Stream Rewind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 vendor/
 composer.lock
 .phpunit.result.cache
+
+docker-compose.yml
+Dockerfile

--- a/src/XmlStringStreamer/Parser/StringWalker.php
+++ b/src/XmlStringStreamer/Parser/StringWalker.php
@@ -71,6 +71,8 @@ class StringWalker implements ParserInterface
      */
     public function __construct(array $options = array())
     {
+        $this->reset();
+
         $this->options = array_merge(array(
             "captureDepth" => 2,
             "expectGT" => false,
@@ -265,5 +267,16 @@ class StringWalker implements ParserInterface
         }
 
         return false;
-	}
+    }
+
+    public function reset()
+    {
+        $this->firstRun = true;
+        $this->depth = 0;
+        $this->chunk = '';
+        $this->lastChunk = null;
+        $this->shaved = null;
+        $this->capture = false;
+        $this->containerXml = "";
+    }
 }

--- a/src/XmlStringStreamer/Parser/StringWalker.php
+++ b/src/XmlStringStreamer/Parser/StringWalker.php
@@ -27,13 +27,13 @@ class StringWalker implements ParserInterface
      * Is this the first run?
      * @var boolean
      */
-    protected $firstRun = true;
+    protected $firstRun;
 
     /**
      * What depth are we currently at?
      * @var integer
      */
-    protected $depth = 0;
+    protected $depth;
 
     /**
      * The latest chunk from the stream
@@ -51,22 +51,22 @@ class StringWalker implements ParserInterface
      * XML node in the making
      * @var null|string
      */
-    protected $shaved = null;
+    protected $shaved;
 
     /**
      * Whether to capture or not
      * @var boolean
      */
-    protected $capture = false;
+    protected $capture;
 
     /**
      * If extractContainer is true, this will grow with the XML captured before and after the specified capture depth
      * @var string
      */
-    protected $containerXml = "";
+    protected $containerXml;
 
     /**
-     * Parser contructor
+     * Parser constructor
      * @param array $options An options array
      */
     public function __construct(array $options = array())

--- a/src/XmlStringStreamer/Parser/UniqueNode.php
+++ b/src/XmlStringStreamer/Parser/UniqueNode.php
@@ -18,57 +18,57 @@ use Prewk\XmlStringStreamer\StreamInterface;
  */
 class UniqueNode implements ParserInterface
 {
+    const FIND_OPENING_TAG_ACTION = 0;
+    const FIND_CLOSING_TAG_ACTION = 1;
+
     /**
      * Current working XML blob
      * @var string
      */
-    private $workingBlob = "";
+    private $workingBlob;
 
     /**
      * The flushed node
      * @var string
      */
-    private $flushed = "";
+    private $flushed;
 
     /**
      * Start position of the given element in the workingBlob
      * @var integer
      */
-    private $startPos = 0;
+    private $startPos;
 
     /**
      * Records how far we've searched in the XML blob so far
      * @var integer
      */
-    private $hasSearchedUntilPos = -1;
-
-    const FIND_OPENING_TAG_ACTION = 0;
-    const FIND_CLOSING_TAG_ACTION = 1;
+    private $hasSearchedUntilPos;
 
     /**
      * Next action to perform
      * @var integer
      */
-    private $nextAction = 0;
+    private $nextAction;
 
     /**
      * Indicates short closing tag
      * @var bool
      */
 
-    private $shortClosedTagNow = false;
+    private $shortClosedTagNow;
 
     /**
      * If extractContainer is true, this will grow with the XML captured before and after the specified capture depth
      * @var string
      */
-    protected $containerXml = "";
+    protected $containerXml;
 
     /**
      * Whether we're found our first capture target or not
      * @var bool
      */
-    protected $preCapture = true;
+    protected $preCapture;
 
     /**
      * Parser constructor

--- a/src/XmlStringStreamer/Parser/UniqueNode.php
+++ b/src/XmlStringStreamer/Parser/UniqueNode.php
@@ -77,6 +77,8 @@ class UniqueNode implements ParserInterface
      */
     public function __construct(array $options = array())
     {
+        $this->reset();
+
         $this->options = array_merge(array(
             "extractContainer" => false,
         ), $options);
@@ -282,5 +284,26 @@ class UniqueNode implements ParserInterface
         }
 
         return $this->containerXml;
+    }
+
+    /**
+     * @internal
+     * @return string
+     */
+    public function getCurrentWorkingBlob()
+    {
+        return $this->workingBlob;
+    }
+
+    public function reset()
+    {
+        $this->workingBlob = '';
+        $this->flushed = '';
+        $this->startPos = 0;
+        $this->hasSearchedUntilPos = -1;
+        $this->nextAction = 0;
+        $this->shortClosedTagNow = false;
+        $this->containerXml = '';
+        $this->preCapture = true;
     }
 }

--- a/src/XmlStringStreamer/ParserInterface.php
+++ b/src/XmlStringStreamer/ParserInterface.php
@@ -31,4 +31,13 @@ interface ParserInterface
      * @return string XML string
      */
     public function getExtractedContainer();
+
+    /**
+     * Reset all Parser internal caches, working blobs, working chunks etc.
+     *
+     * you have to Reset Parser state in case of rewinding Stream (or other Stream manipulation like seek)
+     *
+     * @return void
+     */
+    public function reset();
 }

--- a/tests/xml/rewind_working_blob.xml
+++ b/tests/xml/rewind_working_blob.xml
@@ -1,0 +1,12 @@
+<root>
+    <item>0</item>
+    <item>1</item>
+    <item>2</item>
+    <item>3</item>
+    <item>4</item>
+    <item>5</item>
+    <item>6</item>
+    <item>7</item>
+    <item>8</item>
+    <item>9</item>
+</root>


### PR DESCRIPTION
as per #67  rewinding stream does not reset Parser internal state so once rewindend, few initial chunk products might be corrupted

if you are using Stream Rewind methods,  you have to explicitly Reset Parsers as well

unit tests in this PR are quite verbose to describe what is happening without Reseting Parsers