### PR TITLE
Fix closing tag position detection when not reading from beginning of file

### DIFF
--- a/src/XmlStringStreamer/Parser/UniqueNode.php
+++ b/src/XmlStringStreamer/Parser/UniqueNode.php
@@ -134,7 +134,7 @@ class UniqueNode implements ParserInterface
      */
     protected function getClosingTagPos()
     {
-        $endPositionInBlob = strpos($this->workingBlob, "</" . $this->options["uniqueNode"] . ">");
+        $endPositionInBlob = strpos($this->workingBlob, "</" . $this->options["uniqueNode"] . ">", $this->startPos);
         if ($endPositionInBlob === false) {
 
             if (isset($this->options["checkShortClosing"]) && $this->options["checkShortClosing"] === true) {

--- a/tests/integration/XmlStringStreamer/XmlStringStreamerIntegrationTest.php
+++ b/tests/integration/XmlStringStreamer/XmlStringStreamerIntegrationTest.php
@@ -317,4 +317,26 @@ class XmlStringStreamerIntegrationTest extends TestCase
         $parser->reset();
         self::assertSame("\n    <item>0</item>", $streamer->getNode());
     }
+    
+    public function test_UniqueNode_parser_stream_seeking()
+    {
+        $filePath = __dir__ . '/../../xml/stream_seeking.xml';
+        $fileHandle = fopen($filePath, 'rb');
+        
+        $stream = new XmlStringStreamer\Stream\File($fileHandle, 50);
+        $parser = new UniqueNode(["uniqueNode" => 'item']);
+        $streamer = new XmlStringStreamer($parser, $stream);
+        
+        self::assertSame('<item>first item to read</item>', $streamer->getNode());
+        
+        /**
+         * @see /tests/xml/stream_seeking.xml
+         * hash character is used as seek target in file, creating case where closing tag precedes opening tag
+         */
+        $seekTargetPosition = strpos(file_get_contents($filePath), '#');
+        fseek($fileHandle, $seekTargetPosition);
+        $parser->reset();
+        
+        self::assertSame('<item>second item to read</item>', $streamer->getNode());
+    }
 }

--- a/tests/unit/XmlStringStreamer/Parser/UniqueNodeTest.php
+++ b/tests/unit/XmlStringStreamer/Parser/UniqueNodeTest.php
@@ -263,4 +263,28 @@ eot;
             "When no nodes are left, false should be returned"
         );
     }
+    
+    public function test_orphan_closing_tag_is_ignored()
+    {
+        $expectedStringToBeFlushed = '<child>read this</child>';
+        $xml = <<<eot
+<?xml version="1.0"?>
+<root>
+    </child>
+    $expectedStringToBeFlushed
+</root>
+eot;
+        
+        $stream = $this->getStreamMock($xml, strlen($xml));
+        
+        $parser = new UniqueNode([
+            "uniqueNode" => "child"
+        ]);
+        
+        $this->assertEquals(
+            $expectedStringToBeFlushed,
+            $parser->getNodeFrom($stream),
+            "Orphan closing tag must not act as closing tag for first opening tag"
+        );
+    }
 }

--- a/tests/xml/stream_seeking.xml
+++ b/tests/xml/stream_seeking.xml
@@ -1,0 +1,5 @@
+<root>
+    <item>first item to read</item>
+    <item>seek will land before hash character: #</item>
+    <item>second item to read</item>
+</root>


### PR DESCRIPTION
Follow-up of #77 

Closing tag position in working blob is being detected no matter the position of the opening one. This creates case where length of string to be flushed might become negative, resulting in flushing all of working blob except x characters, where x is difference in position between opening and closing tag.

This update is made to support seeking through stream without invalid items found.