### PR TITLE
Explicitly declare options property of UniqueNode

### DIFF
--- a/src/XmlStringStreamer/Parser/UniqueNode.php
+++ b/src/XmlStringStreamer/Parser/UniqueNode.php
@@ -71,6 +71,11 @@ class UniqueNode implements ParserInterface
     protected $preCapture;
 
     /**
+     * @var array<string, mixed>
+     */
+    private $options;
+
+    /**
      * Parser constructor
      * @param array $options An options array
      * @throws Exception if the required option uniqueNode isn't set


### PR DESCRIPTION
In PHP 8.2 dynamic properties are deprecated and a notice is triggered:
```
Creation of dynamic property Prewk\XmlStringStreamer\Parser\UniqueNode::$options is deprecated
```

I added proper declaration of the missing property.